### PR TITLE
Fix exit condition for page iterator

### DIFF
--- a/page_iterator.go
+++ b/page_iterator.go
@@ -177,7 +177,7 @@ func (pI *PageIterator[T]) enumerate(callback func(item T) bool) bool {
 	}
 
 	// the current page has no items to enumerate
-	if pI.currentPage.getValue() == nil {
+	if len(pI.currentPage.getValue()) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
## Overview
Exit the page iterator if there are no elements in the response of the graph API request

