### PR TITLE
fix(deps): security updates (INTM-6371, INTM-6243)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -41,10 +41,10 @@ go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/
 go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
 go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
## Security dependency updates

Resolves 2 Dependabot alerts. Both are transitive vulnerabilities in `golang.org/x/net`; a single bump to v0.38.0 clears both (v0.38.0 >= both patch floors of 0.36.0 and 0.38.0).

### Fixed
- **golang.org/x/net** `v0.23.0` -> `v0.38.0` (transitive, `go.mod` indirect require)
  - INTM-6371 — CVE-2025-22870 (HTTP Proxy bypass using IPv6 Zone IDs), patched in 0.36.0 — https://linear.app/issue/INTM-6371 — advisory https://github.com/advisories/GHSA-qxp5-gwg8-xv66
  - INTM-6243 — CVE-2025-22872 (Cross-site Scripting in HTML tokenizer), patched in 0.38.0 — https://linear.app/issue/INTM-6243 — advisory https://github.com/advisories/GHSA-vvgc-356p-c3xw

`go mod tidy` also carried `golang.org/x/text` `v0.14.0` -> `v0.23.0` (dependency of x/net).

Fixes INTM-6371
Fixes INTM-6243

### Skipped / already-resolved
None.

### Could not fix
None.

### Verification
- `go build ./...` — pass
- `go vet ./...` — pass

Generated with Claude Code (dependabot-resolver)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only lockfile changes with no direct code edits; risk is limited to possible behavior differences in patched networking/text libraries used transitively by Azure/Kiota stacks.
> 
> **Overview**
> Bumps **transitive** Go module versions in `go.mod` / `go.sum` to clear Dependabot security alerts—no application source changes.
> 
> **`golang.org/x/net`** moves from **v0.23.0** to **v0.38.0**, addressing CVE-2025-22870 (HTTP proxy bypass with IPv6 zone IDs) and CVE-2025-22872 (XSS in the HTML tokenizer). **`golang.org/x/text`** is updated from **v0.14.0** to **v0.23.0** as part of the same `go mod tidy` resolution chain for `x/net`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251dbcab3ba2a0a2b2a6dd22b7e2fbea7dc0388d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->